### PR TITLE
Adds longhorn-ui v1.7.0 rock

### DIFF
--- a/tests/sanity/test_longhorn_ui.py
+++ b/tests/sanity/test_longhorn_ui.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+import pytest
+from k8s_test_harness.util import docker_util, env_util
+
+ROCK_EXPECTED_FILES = [
+    "/bin/pebble",
+    "/etc/nginx/nginx.conf.template",
+    "/entrypoint.sh",
+    "/var/config/nginx",
+    "/var/lib/nginx",
+    "/var/log/nginx",
+    "/var/run/nginx.pid",
+    "/web",
+]
+
+
+@pytest.mark.parametrize("image_version", ["v1.7.0"])
+def test_longhorn_ui_rock(image_version):
+    """Test longhorn-ui rock."""
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "longhorn-ui", image_version, "amd64"
+    )
+    image = rock.image
+
+    # check rock filesystem.
+    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)

--- a/v1.7.0/longhorn-ui/entrypoint.sh
+++ b/v1.7.0/longhorn-ui/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+cp -r /etc/nginx/* /var/config/nginx/
+envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT}' < /etc/nginx/nginx.conf.template > /var/config/nginx/nginx.conf
+
+nginx -c /var/config/nginx/nginx.conf -g 'daemon off;'

--- a/v1.7.0/longhorn-ui/rockcraft.yaml
+++ b/v1.7.0/longhorn-ui/rockcraft.yaml
@@ -1,0 +1,108 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Rockcraft definition for Longhorn UI image:
+# longhornio/longhorn-ui:v1.7.0
+
+# Based on: https://github.com/longhorn/longhorn-ui/blob/v1.7.0/Dockerfile
+name: longhorn-ui
+summary: longhorn-ui rock
+description: |
+    A rock containing Longhorn UI component: https://github.com/longhorn/longhorn-ui
+
+    Longhorn is a distributed block storage system for Kubernetes. Longhorn is cloud-native
+    storage built using Kubernetes and container primitives.
+
+    Aims to replicate the upstream official image: longhornio/longhorn-ui:v1.7.0
+license: Apache-2.0
+
+version: "v1.7.0"
+
+# NOTE(aznashwan): the base for the engine image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/longhorn-ui/blob/v1.7.0/Dockerfile#L13
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: v1.7.0
+  LONGHORN_MANAGER_IP: http://localhost:9500
+  LONGHORN_UI_PORT: 8000
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  longhorn-ui:
+    summary: "longhorn-ui service"
+    override: replace
+    startup: enabled
+    user: nginx
+    group: nginx
+    command: "/entrypoint.sh"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  nginx-user:
+    plugin: nil
+    overlay-script: |
+      groupadd -R $CRAFT_OVERLAY -g 499 nginx
+      useradd -R $CRAFT_OVERLAY -g 499 -u 499 -M -r nginx
+
+  add-entrypoint:
+    after: [nginx-user]
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+      - entrypoint.sh
+    override-stage: |
+      craftctl default
+      chown -R 499 "${CRAFT_PART_INSTALL}/entrypoint.sh"
+
+  add-dependencies:
+    after: [nginx-user]
+    plugin: nil
+    stage-packages:
+      - curl
+      - libxml2
+      - gettext
+      - nginx
+    override-build: |
+      mkdir -p "${CRAFT_PART_INSTALL}/var/config/nginx" \
+        "${CRAFT_PART_INSTALL}/var/lib/nginx" \
+        "${CRAFT_PART_INSTALL}/var/log/nginx" \
+        "${CRAFT_PART_INSTALL}/var/run"
+      touch "${CRAFT_PART_INSTALL}/var/run/nginx.pid"
+      chown -R 499 "${CRAFT_PART_INSTALL}/var/config/nginx" \
+        "${CRAFT_PART_INSTALL}/var/lib/nginx" \
+        "${CRAFT_PART_INSTALL}/var/log/nginx" \
+        "${CRAFT_PART_INSTALL}/var/run/nginx.pid"
+
+  build-longhorn-ui:
+    plugin: nil
+    source: https://github.com/longhorn/longhorn-ui
+    source-type: git
+    source-tag: $CRAFT_PROJECT_VERSION
+    source-depth: 1
+    build-packages:
+      - gettext-base
+    build-snaps:
+      - node/16/stable
+    build-environment:
+      - VERSION: $CRAFT_PROJECT_VERSION
+    override-build: |
+      npm ci
+      # Inject the version before building.
+      sed -i -e "s/\${VERSION}/${VERSION}/" src/utils/config.js
+      npm run build
+
+      mkdir -p "${CRAFT_PART_INSTALL}/etc/nginx" "${CRAFT_PART_INSTALL}/web"
+      cp nginx.conf.template "${CRAFT_PART_INSTALL}/etc/nginx/"
+
+      # nginx.conf.template has /web/dist location set in it.
+      cp -r dist "${CRAFT_PART_INSTALL}/web/"


### PR DESCRIPTION
Added an ``entrypoint.sh`` script in order to have a simpler service command.

Note that the ``/web/dist`` location is hard-coded in ``nginx.conf.template``, which is ultimately used to configure nginx.

Added sanity test for the mentioned rock.