### PR TITLE
Enhances the longhorn integration test

### DIFF
--- a/tests/templates/nginx-pod.yaml
+++ b/tests/templates/nginx-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: longhorn-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-longhorn-example
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+      - name: longhorn-pvc
+        mountPath: /var/www
+        readOnly: false
+  volumes:
+    - name: longhorn-pvc
+      persistentVolumeClaim:
+        claimName: longhorn-pvc


### PR DESCRIPTION
The integration test now also waits for the ``"driver.longhorn.io"`` annotation to be added to the node. If this is added, it means that the Longhorn CSI plugin successfully registered.

The integration now spawns an NGINX pod with a PVC, which should be satisfied by Longhorn.