### PR TITLE
Updates the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ upstream images:
 * longhornio/longhorn-share-manager
 * longhornio/backing-image-manager
 * longhornio/support-bundle-kit
+
+The CSI components required by Longhorn can be found here: https://github.com/canonical/csi-rocks. The repository contains the rock equivalent of the following images:
+
 * longhornio/csi-attacher
 * longhornio/csi-provisioner
 * longhornio/csi-node-driver-registrar
 * longhornio/csi-resizer
 * longhornio/csi-snapshotter
 * longhornio/livenessprobe
-* longhornio/openshift-origin-oauth-proxy

--- a/v1.7.0/README.md
+++ b/v1.7.0/README.md
@@ -9,10 +9,12 @@ Aim to be compatible with following upstream images:
 * longhornio/longhorn-share-manager:v1.7.0
 * longhornio/backing-image-manager:v1.7.0
 * longhornio/support-bundle-kit:v0.0.41
-* longhornio/csi-attacher:v4.6.1
-* longhornio/csi-provisioner:v4.0.1
-* longhornio/csi-node-driver-registrar:v2.11.1
-* longhornio/csi-resizer:v1.11.1
-* longhornio/csi-snapshotter:v7.0.2
-* longhornio/livenessprobe:v2.13.1
-* longhornio/openshift-origin-oauth-proxy:4.15
+
+The CSI components required by Longhorn can be found here: https://github.com/canonical/csi-rocks. The rocks required by Longhorn v1.7.0 are:
+
+* ghcr.io/canonical/csi-attacher:4.6.1-ck5
+* ghcr.io/canonical/csi-provisioner:4.0.1-ck4
+* ghcr.io/canonical/csi-node-driver-registrar:2.11.1-ck3
+* ghcr.io/canonical/csi-resizer:1.11.1-ck1
+* ghcr.io/canonical/csi-snapshotter:7.0.2-ck2
+* ghcr.io/canonical/livenessprobe:2.13.1-ck0


### PR DESCRIPTION
The CSI rocks are hosted on a separate repository. Updates the README files to reflect this detail.

Additionally, the rock for ``openshift-origin-oauth-proxy`` is not added to this repository.