### PR TITLE
Fixes sanity tests

### DIFF
--- a/tests/sanity/test_longhorn_share_manager.py
+++ b/tests/sanity/test_longhorn_share_manager.py
@@ -6,7 +6,6 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 ROCK_EXPECTED_FILES = [
-    "/bin/pebble",
     "/etc/dbus-1/system.d/org.ganesha.nfsd.conf",
     "/etc/ld.so.conf.d/local_libs.conf",
     "/etc/mtab",

--- a/tests/sanity/test_longhorn_ui.py
+++ b/tests/sanity/test_longhorn_ui.py
@@ -6,7 +6,6 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 ROCK_EXPECTED_FILES = [
-    "/bin/pebble",
     "/etc/nginx/nginx.conf.template",
     "/entrypoint.sh",
     "/var/config/nginx",

--- a/tests/sanity/test_support_bundle_kit.py
+++ b/tests/sanity/test_support_bundle_kit.py
@@ -6,7 +6,6 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 ROCK_EXPECTED_FILES = [
-    "/bin/pebble",
     "/tmp/common",
     "/usr/bin/entrypoint.sh",
     "/usr/bin/collector-harvester",

--- a/v1.7.0/support-bundle-kit/v0.0.41/rockcraft.yaml
+++ b/v1.7.0/support-bundle-kit/v0.0.41/rockcraft.yaml
@@ -46,7 +46,7 @@ parts:
       - yq
 
   add-support-bundle-kit:
-    plugin: go
+    plugin: nil
     source: https://github.com/rancher/support-bundle-kit
     source-type: git
     source-tag: $CRAFT_PROJECT_VERSION
@@ -58,14 +58,14 @@ parts:
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - CGO_ENABLED: 0
       - VERSION: $CRAFT_PROJECT_VERSION
-    go-buildtags:
-      - "ldflags='-extldflags -static -s -X github.com/rancher/support-bundle-kit/cmd.AppVersion=$VERSION'"
     organize:
       bin/support-bundle-kit: usr/bin/
     override-build: |
-      craftctl default
-
       mkdir -p "${CRAFT_PART_INSTALL}/usr/bin/" "${CRAFT_PART_INSTALL}/tmp"
+
+      LINKFLAGS="-extldflags -static -s -X github.com/rancher/support-bundle-kit/cmd.AppVersion=$VERSION"
+      go build -o $CRAFT_PART_INSTALL/usr/bin/ -ldflags "$LINKFLAGS"
+
       cp package/entrypoint.sh "${CRAFT_PART_INSTALL}/usr/bin/"
       cp hack/support-bundle-collector.sh hack/collector-* "${CRAFT_PART_INSTALL}/usr/bin/"
       cp hack/common "${CRAFT_PART_INSTALL}/tmp"


### PR DESCRIPTION
Removes ``pebble`` from the list of files to check in sanity tests.

``support-bundle-kit`` binary doesn't have the version set in the binary, as it should. This PR addresses this issue.