### PR TITLE
Adds longhorn-manager command patch

### DIFF
--- a/v1.7.0/longhorn-manager/longhorn-csi-plugin-command.patch
+++ b/v1.7.0/longhorn-manager/longhorn-csi-plugin-command.patch
@@ -1,0 +1,13 @@
+diff --git a/csi/deployment.go b/csi/deployment.go
+index 68ed5c5f2..b0e523a4a 100644
+--- a/csi/deployment.go
++++ b/csi/deployment.go
+@@ -375,7 +375,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
+ 									},
+ 								},
+ 							},
+-							Args: []string{
++							Command: []string{
+ 								"longhorn-manager",
+ 								"-d",
+ 								"csi",

--- a/v1.7.0/longhorn-manager/rockcraft.yaml
+++ b/v1.7.0/longhorn-manager/rockcraft.yaml
@@ -61,6 +61,22 @@ parts:
       - CGO_ENABLED: 0
       - VERSION: $CRAFT_PROJECT_VERSION
     override-build: |
+      # NOTE(claudiub): The original longhorn-manager image doesn't have an entrypoint, only a CMD.
+      # This means that when the image is launched, it will run the CMD directly. Basically, the
+      # CMD is the ENTRYPOINT (binary + arguments). That works fine with the current deployments.
+      #
+      # longhorn-manager will create the daemonset.apps/longhorn-csi-plugin, which will
+      # have a longhorn-manager container, which doesn't override the entrypoint, only the
+      # args (aka CMD).
+      # But in our rock scenario, Pebble is the entrypoint, which will get those arguments and pass them
+      # on onto the service defined above. This results in an invalid command being run, something like:
+      # longhorn-manager -d daemon longhorn-manager -d csi --nodeid=...
+      #
+      # This patch updates the mentioned container args to command, overriding the Pebble entrypoint,
+      # avoiding this problem.
+      cp $CRAFT_PROJECT_DIR/longhorn-csi-plugin-command.patch ./
+      git apply -v longhorn-csi-plugin-command.patch
+
       # https://github.com/longhorn/longhorn-manager/blob/v1.7.0/package/Dockerfile#L15
       mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
       cp package/launch-manager package/nsmounter $CRAFT_PART_INSTALL/usr/local/sbin/


### PR DESCRIPTION
The original longhorn-manager image doesn't have an entrypoint, only a ``CMD``. This means that when the image is launched, it will run the ``CMD`` directly. Basically, the ``CMD`` is the ``ENTRYPOINT`` (binary + arguments). That works fine with the current deployments.

longhorn-manager will create the ``daemonset.apps/longhorn-csi-plugin``, which will have a longhorn-manager container, which doesn't override the entrypoint, only the args (aka ``CMD``).
But in our rock scenario, Pebble is the entrypoint, which will get those arguments and pass them on onto the service defined above. This results in an invalid command being run, something like:

```
longhorn-manager -d daemon longhorn-manager -d csi --nodeid=...
```

This patch updates the mentioned container args to command, overriding the Pebble entrypoint, avoiding this problem.