### PR TITLE
Adds longhorn-manager v1.6.2 rock

### DIFF
--- a/tests/sanity/test_longhorn_manager.py
+++ b/tests/sanity/test_longhorn_manager.py
@@ -12,7 +12,7 @@ ROCK_EXPECTED_FILES = [
 ]
 
 
-@pytest.mark.parametrize("image_version", ["v1.7.0"])
+@pytest.mark.parametrize("image_version", ["v1.6.2", "v1.7.0"])
 def test_longhorn_manager_rock(image_version):
     """Test longhorn-manager rock."""
     rock = env_util.get_build_meta_info_for_rock_version(

--- a/v1.6.2/longhorn-manager/longhorn-csi-plugin-command.patch
+++ b/v1.6.2/longhorn-manager/longhorn-csi-plugin-command.patch
@@ -1,0 +1,13 @@
+diff --git a/csi/deployment.go b/csi/deployment.go
+index 470aa22da..d9b6a0596 100644
+--- a/csi/deployment.go
++++ b/csi/deployment.go
+@@ -366,7 +366,7 @@ func NewPluginDeployment(namespace, serviceAccount, nodeDriverRegistrarImage, li
+ 									},
+ 								},
+ 							},
+-							Args: []string{
++							Command: []string{
+ 								"longhorn-manager",
+ 								"-d",
+ 								"csi",

--- a/v1.6.2/longhorn-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-manager/rockcraft.yaml
@@ -1,0 +1,101 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Rockcraft definition for Longhorn manager image:
+# longhornio/longhorn-manager:v1.6.2
+
+name: longhorn-manager
+summary: Rock containing Longhorn manager component.
+description: |
+  Rock containing Longhorn manager component: https://github.com/longhorn/longhorn-manager
+  Aims to replicate the upstream official image: longhornio/longhorn-manager:v1.6.2
+license: Apache-2.0
+
+version: "v1.6.2"
+
+# NOTE(aznashwan): the base for the manager image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 5 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/longhorn-manager/blob/v1.6.2/package/Dockerfile#L1
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+
+services:
+  longhorn-manager:
+    summary: "longhorn-manager service"
+    startup: enabled
+    override: replace
+    # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/package/Dockerfile#L10
+    command: "launch-manager"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  # NOTE(aznashwan): the longhorn binary is built within a Docker container
+  # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
+  # The setup steps for the build container are contained within this Dockerfile:
+  # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/Dockerfile.dapper
+  # The Makefile targets are just the scripts found in the scripts/ directory which
+  # are executed within the Dapper build container:
+  # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/Makefile#L10-L11
+  build-longhorn-manager:
+    plugin: nil
+    source-type: git
+    source: https://github.com/longhorn/longhorn-manager
+    source-tag: ${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-packages:
+      # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/Dockerfile.dapper#L8
+      - gcc
+      - ca-certificates
+      # - libdevmapper1_03
+      - libltdl7
+    build-snaps:
+      # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/Dockerfile.dapper#L19
+      - go/1.21/stable
+    build-environment:
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - CGO_ENABLED: 0
+      - VERSION: $CRAFT_PROJECT_VERSION
+    override-build: |
+      # NOTE(claudiub): The original longhorn-manager image doesn't have an entrypoint, only a CMD.
+      # This means that when the image is launched, it will run the CMD directly. Basically, the
+      # CMD is the ENTRYPOINT (binary + arguments). That works fine with the current deployments.
+      #
+      # longhorn-manager will create the daemonset.apps/longhorn-csi-plugin, which will
+      # have a longhorn-manager container, which doesn't override the entrypoint, only the
+      # args (aka CMD).
+      # But in our rock scenario, Pebble is the entrypoint, which will get those arguments and pass them
+      # on onto the service defined above. This results in an invalid command being run, something like:
+      # longhorn-manager -d daemon longhorn-manager -d csi --nodeid=...
+      #
+      # This patch updates the mentioned container args to command, overriding the Pebble entrypoint,
+      # avoiding this problem.
+      cp $CRAFT_PROJECT_DIR/longhorn-csi-plugin-command.patch ./
+      git apply -v longhorn-csi-plugin-command.patch
+
+      # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/package/Dockerfile#L6
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
+      cp package/launch-manager package/nsmounter $CRAFT_PART_INSTALL/usr/local/sbin/
+
+      # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/scripts/build#L23
+      LINKFLAGS="-X github.com/longhorn/longhorn-manager/meta.Version=$VERSION -extldflags -static -s"
+      go build -o $CRAFT_PART_INSTALL/usr/local/sbin/ -ldflags "$LINKFLAGS"
+
+  add-packages:
+    plugin: nil
+    # https://github.com/longhorn/longhorn-manager/blob/v1.6.2/package/Dockerfile#L3
+    stage-packages:
+      - iproute2
+      - nfs-common  # nfs-client
+      - cifs-utils
+      - bind9-utils  # bind-utils
+      - e2fsprogs
+      - xfsprogs
+      - zip
+      - unzip
+    stage-snaps:
+      - iputils


### PR DESCRIPTION
Based on the v1.7.0 rock and upstream Dockerfile. The golang version was updated. This version doesn't have the ``kmod`` package.

Updates unit test to also test the new image.