### PR TITLE
Adds longhorn-share-manager v1.6.2 rock

### DIFF
--- a/tests/sanity/test_longhorn_share_manager.py
+++ b/tests/sanity/test_longhorn_share_manager.py
@@ -16,8 +16,14 @@ ROCK_EXPECTED_FILES = [
     "/var/run/dbus",
 ]
 
+GANESHA_VERSIONS = {
+    # Longhorn version: Ganesha version
+    "v1.6.2": "V5.7",
+    "v1.7.0": "V5.9",
+}
 
-@pytest.mark.parametrize("image_version", ["v1.7.0"])
+
+@pytest.mark.parametrize("image_version", ["v1.6.2", "v1.7.0"])
 def test_longhorn_share_manager_rock(image_version):
     """Test longhorn-share-manager rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
@@ -44,4 +50,5 @@ def test_longhorn_share_manager_rock(image_version):
     assert "longhorn-share-manager - A new cli application" in process.stdout
 
     process = docker_util.run_in_docker(image, ["ganesha.nfsd", "-v"])
-    assert "NFS-Ganesha Release = V5.9" in process.stdout
+    ganesha_version = GANESHA_VERSIONS[image_version]
+    assert f"NFS-Ganesha Release = {ganesha_version}" in process.stdout

--- a/v1.6.2/longhorn-share-manager/correct-include-assert.patch
+++ b/v1.6.2/longhorn-share-manager/correct-include-assert.patch
@@ -1,0 +1,96 @@
+diff --git a/src/clnt_raw.c b/src/clnt_raw.c
+index 781cfa62..0b768c01 100644
+--- a/src/clnt_raw.c
++++ b/src/clnt_raw.c
+@@ -40,7 +40,6 @@
+ #include "config.h"
+ #include <pthread.h>
+ #include <reentrant.h>
+-#include <assert.h>
+ #include <err.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/src/clnt_vc.c b/src/clnt_vc.c
+index 57d48af7..9c185858 100644
+--- a/src/clnt_vc.c
++++ b/src/clnt_vc.c
+@@ -55,7 +55,6 @@
+ #include <sys/socket.h>
+ #include <misc/socket.h>
+ #include <arpa/inet.h>
+-#include <assert.h>
+ #include <err.h>
+ #include <errno.h>
+ #include <netdb.h>
+diff --git a/src/rbtree_x.c b/src/rbtree_x.c
+index 585af809..5bb05822 100644
+--- a/src/rbtree_x.c
++++ b/src/rbtree_x.c
+@@ -31,7 +31,6 @@
+ #include <err.h>
+ #endif
+ #include <stdint.h>
+-#include <assert.h>
+ #include <errno.h>
+ #include <rpc/types.h>
+ #include <reentrant.h>
+diff --git a/src/svc_ioq.c b/src/svc_ioq.c
+index 1ebcfb06..2d7e18af 100644
+--- a/src/svc_ioq.c
++++ b/src/svc_ioq.c
+@@ -37,7 +37,6 @@
+ #include <netinet/in.h>
+ #include <netinet/tcp.h>
+ 
+-#include <assert.h>
+ #include <err.h>
+ #include <errno.h>
+ #include <fcntl.h>
+diff --git a/src/svc_rqst.c b/src/svc_rqst.c
+index fe8443c9..86bb4d86 100644
+--- a/src/svc_rqst.c
++++ b/src/svc_rqst.c
+@@ -28,7 +28,6 @@
+ #include <sys/types.h>
+ #include <sys/poll.h>
+ #include <stdint.h>
+-#include <assert.h>
+ #include <err.h>
+ #include <errno.h>
+ #include <unistd.h>
+diff --git a/src/svc_xprt.c b/src/svc_xprt.c
+index 4ea9ca02..762d3eb4 100644
+--- a/src/svc_xprt.c
++++ b/src/svc_xprt.c
+@@ -29,7 +29,6 @@
+ #include <sys/types.h>
+ #include <sys/poll.h>
+ #include <stdint.h>
+-#include <assert.h>
+ #include <err.h>
+ #include <errno.h>
+ #include <unistd.h>
+diff --git a/src/work_pool.c b/src/work_pool.c
+index 5d69f557..0ff85008 100644
+--- a/src/work_pool.c
++++ b/src/work_pool.c
+@@ -50,6 +50,7 @@
+ #include <sys/types.h>
+ #include <misc/abstract_atomic.h>
+ #include <misc/portable.h>
++#include <assert.h>
+ #include <stddef.h>
+ #include <stdlib.h>
+ #include <string.h>
+diff --git a/src/xdr_rdma.c b/src/xdr_rdma.c
+index e7f4dfe5..e32dde01 100644
+--- a/src/xdr_rdma.c
++++ b/src/xdr_rdma.c
+@@ -35,7 +35,6 @@
+ 
+ #include <netinet/in.h>
+ 
+-#include <assert.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <errno.h>

--- a/v1.6.2/longhorn-share-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-share-manager/rockcraft.yaml
@@ -1,0 +1,173 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Rockcraft definition for Longhorn share manager image:
+# longhornio/longhorn-share-manager:v1.6.2
+
+name: longhorn-share-manager
+summary: Rock containing Longhorn share manager component.
+description: |
+  Rock containing Longhorn share manager component: https://github.com/longhorn/longhorn-share-manager
+  Aims to replicate the upstream official image: longhornio/longhorn-share-manager:v1.6.2
+license: Apache-2.0
+
+version: "v1.6.2"
+
+# NOTE(aznashwan): the base for the share manager image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 5 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L42
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+
+services:
+  longhorn-share-manager:
+    summary: "longhorn-share-manager service"
+    startup: enabled
+    override: replace
+    # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L72
+    command: "/longhorn-share-manager"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  # NOTE(aznashwan): the longhorn binary is built within a Docker container
+  # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
+  # The setup steps for the build container are contained within this Dockerfile:
+  # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/Dockerfile.dapper
+  # The Makefile targets are just the scripts found in the scripts/ directory which
+  # are executed within the Dapper build container:
+  # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/Makefile#L10-L11
+  build-longhorn-share-manager:
+    plugin: nil
+    source-type: git
+    source: https://github.com/longhorn/longhorn-share-manager
+    source-tag: ${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+
+    build-packages:
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/Dockerfile.dapper#L21
+      - gcc
+      - linux-libc-dev  # linux-glibc-devel
+      - libc6-dev  # glibc-devel
+    build-snaps:
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/Dockerfile.dapper#L34
+      - go/1.21/stable
+    build-environment:
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - CGO_ENABLED: 0
+      - VERSION: $CRAFT_PROJECT_VERSION
+    override-build: |
+      LINKFLAGS="-X main.Version=$VERSION -extldflags -static -s"
+      go build -o $CRAFT_PART_INSTALL/ -ldflags "$LINKFLAGS"
+
+  # Based on:
+  # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L17-L22
+  # https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/blob/7027d6505a510673579c03db589bcb02cc8eda0b/deploy/base/Dockerfile
+  build-ganesha:
+    plugin: nil
+    source-type: git
+    source: https://github.com/nfs-ganesha/nfs-ganesha
+    source-tag: V5.7
+    source-depth: 1
+    # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L12-L14
+    build-packages:
+      - autoconf
+      - bison
+      - cmake
+      - doxygen
+      - git
+      - gcc  # gcc-c++
+      - flex
+      - libgl1-mesa-dev  # Mesa-libGL-devel
+      - libdbus-1-3
+      - libdbus-1-dev  # dbus-1-devel
+      - libnfsidmap-dev  # nfsidmap-devel
+      - liburcu-dev  # liburcu-devel
+      - libblkid-dev  # libblkid-devel
+      - e2fsprogs
+      - xfsprogs
+      - lsb-release
+      - graphviz-dev  # graphviz-devel
+      - libnsl-dev  # libnsl-devel
+      - libcurl4-gnutls-dev  # libcurl-devel
+      - libjson-c-dev  # libjson-c-devel
+      - libacl1-dev  # libacl-devel
+
+    # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L48
+    stage-packages:
+      - rpcbind
+      - libblkid1
+      # - liburcu6 - already included.
+      - dbus-x11  # dbus-1-x11
+      - libdbus-1-3  # dbus-1
+      - libnfsidmap-dev  # nfsidmap-devel
+      - nfs-kernel-server
+      - nfs-common  # nfs-client
+      - nfs4-acl-tools
+      - xfsprogs
+      - e2fsprogs
+
+    override-build: |
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L17-L22
+      curl -L https://github.com/nfs-ganesha/ntirpc/archive/refs/tags/v5.0.tar.gz | tar zx
+
+      # Currently, ntirpc v5.0 fails to build with the following error:
+      # /usr/bin/ld: libntirpc/src/libntirpc.so.5.0: undefined reference to `assert'
+      # This issue has been fixed in v5.8 and newer.
+      # We're applying that bug fix patch: https://github.com/nfs-ganesha/ntirpc/pull/279
+      # Moving to /tmp, so we can apply the patch.
+      mv ntirpc-5.0 /tmp/
+      pushd /tmp/ntirpc-5.0
+      cp $CRAFT_PROJECT_DIR/correct-include-assert.patch ./
+      git apply -v correct-include-assert.patch
+      popd
+
+      rm -r src/libntirpc
+      mv /tmp/ntirpc-5.0 src/libntirpc
+
+      # build ganesha only supporting nfsv4 and vfs.
+      # set NFS_V4_RECOV_ROOT to /tmp we don't support recovery in this release.
+      # we disable dbus (-DUSE_DBUS=OFF) for the single share manager since we don't use dynamic exports.
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L28
+      cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only \
+        -DUSE_DBUS=OFF -DUSE_NFS3=OFF -DUSE_NLM=OFF -DUSE_RQUOTA=OFF -DUSE_9P=OFF -D_MSPAC_SUPPORT=OFF -DRPCBIND=OFF \
+        -DUSE_RADOS_RECOV=OFF -DRADOS_URLS=OFF -DUSE_FSAL_VFS=ON -DUSE_FSAL_XFS=OFF \
+        -DUSE_FSAL_PROXY_V4=OFF -DUSE_FSAL_PROXY_V3=OFF -DUSE_FSAL_LUSTRE=OFF -DUSE_FSAL_LIZARDFS=OFF \
+        -DUSE_FSAL_KVSFS=OFF -DUSE_FSAL_CEPH=OFF -DUSE_FSAL_GPFS=OFF -DUSE_FSAL_PANFS=OFF -DUSE_FSAL_GLUSTER=OFF \
+        -DUSE_GSS=NO -DHAVE_ACL_GET_FD_NP=ON -DHAVE_ACL_SET_FD_NP=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local src/
+
+      make
+      make install
+
+      # ganesha.nfsd needs to be linked with its libganesha_nfsd.so.
+      # ldconfig will generate /etc/ld.so.cache, which we'll need to include in the final image.
+      ldconfig
+
+      mkdir -p $CRAFT_PART_INSTALL/etc/ld.so.conf.d $CRAFT_PART_INSTALL/usr/local
+      cp /etc/ld.so.cache $CRAFT_PART_INSTALL/etc/
+      cp -R /usr/local/bin $CRAFT_PART_INSTALL/usr/local/
+      cp -R /usr/local/lib $CRAFT_PART_INSTALL/usr/local/
+
+      # ganesha reads /etc/mtab for mounted volumes.
+      ln -sf /proc/self/mounts $CRAFT_PART_INSTALL/etc/mtab
+
+      # create and add the ganesha-extra files.
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.7.0/package/Dockerfile#L40
+      mkdir -p $CRAFT_PART_INSTALL/etc/dbus-1/system.d
+      cp src/scripts/ganeshactl/org.ganesha.nfsd.conf $CRAFT_PART_INSTALL/etc/dbus-1/system.d/ 
+
+      # add libs from /usr/local/lib64
+      # https://github.com/longhorn/longhorn-share-manager/blob/v1.7.0/package/Dockerfile#L62
+      echo /usr/local/lib64 > $CRAFT_PART_INSTALL/etc/ld.so.conf.d/local_libs.conf
+
+      # create other files.
+      mkdir -p $CRAFT_PART_INSTALL/var/run/dbus $CRAFT_PART_INSTALL/export
+
+      # do not ask systemd for user IDs or groups (slows down dbus-daemon start),
+      cp /etc/nsswitch.conf $CRAFT_PART_INSTALL/etc/
+      sed -i s/systemd// $CRAFT_PART_INSTALL/etc/nsswitch.conf


### PR DESCRIPTION
Based on the v1.7.0 rock and upstream Dockerfile. The golang version was updated. The ``nfs-ganesha`` version V5.7. Does not include the ``libjson-c*`` package.

We're applying a patch to the downloaded ``ntirpc`` v5.0 in order to be able to build it. This building issue has been resolved in v5.8 and newer.

Updates unit test to also test the new image.