### PR TITLE
Adds support-bundle-kit v0.0.37 rock

### DIFF
--- a/tests/sanity/test_support_bundle_kit.py
+++ b/tests/sanity/test_support_bundle_kit.py
@@ -6,7 +6,6 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 ROCK_EXPECTED_FILES = [
-    "/tmp/common",
     "/usr/bin/entrypoint.sh",
     "/usr/bin/collector-harvester",
     "/usr/bin/collector-k3os",
@@ -17,7 +16,7 @@ ROCK_EXPECTED_FILES = [
 ]
 
 
-@pytest.mark.parametrize("image_version", ["v0.0.41"])
+@pytest.mark.parametrize("image_version", ["v0.0.37", "v0.0.41"])
 def test_support_bundle_kit_rock(image_version):
     """Test support-bundle-kit rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
@@ -26,6 +25,9 @@ def test_support_bundle_kit_rock(image_version):
     image = rock.image
 
     # check rock filesystem.
+    expected_files = ROCK_EXPECTED_FILES
+    if image_version != "v0.0.37":
+        expected_files += ["/tmp/common"]
     docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
 
     # check expected executables.
@@ -37,4 +39,4 @@ def test_support_bundle_kit_rock(image_version):
     assert "yq is a portable command-line data file processor" in process.stdout
 
     process = docker_util.run_in_docker(image, ["support-bundle-kit", "version"])
-    assert "v0.0.41" in process.stdout
+    assert image_version in process.stdout

--- a/v1.6.2/support-bundle-kit/v0.0.37/rockcraft.yaml
+++ b/v1.6.2/support-bundle-kit/v0.0.37/rockcraft.yaml
@@ -1,0 +1,73 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/rancher/support-bundle-kit/blob/v0.0.37/package/Dockerfile
+name: support-bundle-kit
+summary: support-bundle-kit rock
+description: |
+    A rock containing support-bundle-kit: https://github.com/rancher/support-bundle-kit
+
+    It contains support bundle scripts and utilities for applications running on top
+    of Kubernetes.
+
+    Aims to replace the upstream official image: rancher/support-bundle-kit:v0.0.37
+license: Apache-2.0
+version: v0.0.37
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+run-user: _daemon_
+
+platforms:
+  amd64:
+
+environment:
+  APP_VERSION: v0.0.37
+  TINI_VERSION: v0.19.0
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  support-bundle-kit:
+    summary: "support-bundle-kit service"
+    override: replace
+    startup: enabled
+    command: "entrypoint.sh"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  add-packages:
+    plugin: nil
+    stage-packages:
+      - curl
+      - tini=0.19.0-1
+      - zip
+    stage-snaps:
+      - yq
+
+  add-support-bundle-kit:
+    plugin: nil
+    source: https://github.com/rancher/support-bundle-kit
+    source-type: git
+    source-tag: $CRAFT_PROJECT_VERSION
+    source-depth: 1
+    build-snaps:
+      - go/1.20/stable
+    build-environment:
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - CGO_ENABLED: 0
+      - VERSION: $CRAFT_PROJECT_VERSION
+    organize:
+      bin/support-bundle-kit: usr/bin/
+    override-build: |
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/bin/" "${CRAFT_PART_INSTALL}/tmp"
+
+      LINKFLAGS="-extldflags -static -s -X github.com/rancher/support-bundle-kit/cmd.AppVersion=$VERSION"
+      go build -o $CRAFT_PART_INSTALL/usr/bin/ -ldflags "$LINKFLAGS"
+
+      cp package/entrypoint.sh "${CRAFT_PART_INSTALL}/usr/bin/"
+      cp hack/support-bundle-collector.sh hack/collector-* "${CRAFT_PART_INSTALL}/usr/bin/"
+
+      # Not all scripts have the executable right, but they should.
+      chmod +x ${CRAFT_PART_INSTALL}/usr/bin/*


### PR DESCRIPTION
Based on the v0.0.41 rock and upstream Dockerfile. The golang version was updated. This version doesn't have the ``"/tmp/common"`` path.

Updates unit test to also test the new image.