### PR TITLE
Add v1.6.2 definitions for the engine, instance-manager, and backing-image-manager ROCKs.

### DIFF
--- a/tests/sanity/test_longhorn_backing_image_manager.py
+++ b/tests/sanity/test_longhorn_backing_image_manager.py
@@ -15,7 +15,7 @@ LOG.addHandler(logging.StreamHandler(sys.stdout))
 
 
 IMAGE_NAME = "backing-image-manager"
-IMAGE_VERSIONS = ["v1.7.0"]
+IMAGE_VERSIONS = ["v1.6.2", "v1.7.0"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/sanity/test_longhorn_engine.py
+++ b/tests/sanity/test_longhorn_engine.py
@@ -15,7 +15,7 @@ LOG.addHandler(logging.StreamHandler(sys.stdout))
 
 
 IMAGE_NAME = "longhorn-engine"
-IMAGE_VERSIONS = ["v1.7.0"]
+IMAGE_VERSIONS = ["v1.6.2", "v1.7.0"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/sanity/test_longhorn_instance_manager.py
+++ b/tests/sanity/test_longhorn_instance_manager.py
@@ -15,7 +15,7 @@ LOG.addHandler(logging.StreamHandler(sys.stdout))
 
 
 IMAGE_NAME = "longhorn-instance-manager"
-IMAGE_VERSIONS = ["v1.7.0"]
+IMAGE_VERSIONS = ["v1.6.2", "v1.7.0"]
 
 
 @pytest.mark.abort_on_fail
@@ -80,5 +80,11 @@ def test_check_rock_image_contents(image_version):
     # to re-index some libs `nvme` dynamically links to:
     cmd = "ldconfig && nvme version"
     process = docker_util.run_in_docker(rock_image, ["bash", "-c", cmd])
-    assert "nvme version 2.9.1" in process.stdout
-    assert "libnvme version 1.9" in process.stdout
+    nvme_cli_and_lib_ver_map = {
+        "v1.7.0": ("2.9.1", "1.9"),
+        "v1.6.2": ("2.7.1", "1.7"),
+    }
+    LOG.info(f"`nvme version` output: {process.stdout}")
+    cliv, libv = nvme_cli_and_lib_ver_map[image_version]
+    assert f"nvme version {cliv}" in process.stdout
+    assert f"libnvme version {libv}" in process.stdout

--- a/v1.6.2/README.md
+++ b/v1.6.2/README.md
@@ -1,0 +1,23 @@
+# Canonical ROCKs for Longhorn v1.6.2
+
+Aim to be compatible with following upstream images
+[listed in the v1.6.2 release of Longhorn](https://github.com/longhorn/longhorn/releases/download/v1.6.2/longhorn-images.txt).
+
+* longhornio/longhorn-engine:v1.6.2
+* longhornio/longhorn-manager:v1.6.2
+* longhornio/longhorn-ui:v1.6.2
+* longhornio/longhorn-instance-manager:v1.6.2
+* longhornio/longhorn-share-manager:v1.6.2
+* longhornio/backing-image-manager:v1.6.2
+* longhornio/support-bundle-kit:v0.0.37
+
+The CSI components required by Longhorn can be found here: https://github.com/canonical/csi-rocks.
+
+The CSI rocks required for a Longhorn v1.6.2 deplyoment are:
+
+* ghcr.io/canonical/csi-attacher:v4.5.1
+* ghcr.io/canonical/csi-provisioner:v3.6.4
+* ghcr.io/canonical/csi-node-driver-registrar:v2.9.2
+* ghcr.io/canonical/csi-resizer:v1.10.1
+* ghcr.io/canonical/csi-snapshotter:v6.3.4
+* ghcr.io/canonical/livenessprobe:v2.12.0

--- a/v1.6.2/backing-image-manager/rockcraft.yaml
+++ b/v1.6.2/backing-image-manager/rockcraft.yaml
@@ -1,0 +1,144 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Rockcraft definition for the Longhorn Backing Image Manager image:
+# longhornio/backing-image-manager:v1.7.0
+
+name: backing-image-manager
+summary: Rock containing the Longhorn Backing Image Manager component.
+description: |
+  Rock containing Longhorn Backing Image manager component: https://github.com/longhorn/backing-image-manager
+  Aims to replicate the upstream official image: longhornio/backing-image-manager:v1.7.0
+license: Apache-2.0
+
+version: "v1.7.0"
+
+# NOTE(aznashwan): the base for the image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L3
+base: ubuntu@24.04
+
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+
+
+services:
+  backing-image-manager:
+    startup: enabled
+    override: replace
+
+    # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L31-L33
+    command: /tini -- [ backing-image-manager ]
+
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: backing-image-manager
+
+parts:
+
+  # NOTE(aznashwan): the binary is built within a Docker container
+  # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
+  # The setup steps for the build container are contained within this Dockerfile:
+  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper
+  setup-build-env:
+    plugin: nil
+
+    build-packages:
+      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper#L20-L24
+      - cmake
+      - wget
+      - curl
+      - git
+      - less
+      - file
+      - libkmod-dev             # libkmod-devel
+      - libnl-3-dev             # libnl3-devel
+      - linux-headers-6.8.0-41  # linux-glibc-devel
+      - pkg-config
+      - psmisc
+      - fuse
+      - librdmacm-dev           # librdmacm1
+      - rdmacm-utils            # librdmacm-utils
+      - libibverbs-dev          # libibverbs
+      - libaio-dev              # libaio-devel
+      - libc6-dev               # glibc-devel, glibc-devel-static
+      - iptables
+      - libltdl7
+      - libdevmapper1.02.1      # libdevmapper1_03
+      - iproute2
+      - jq
+      - gcc
+
+  # NOTE(aznashwan): the Makefile targets are just the scripts found in the
+  # scripts/ directory which are executed within the Dapper build container:
+  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Makefile#L1
+  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Makefile#L10-L11
+  build-lonhorn-backing-image-manager:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/backing-image-manager
+    source-tag: v1.7.0
+    source-depth: 1
+
+    build-snaps:
+      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper#L1
+      - go/1.22/stable
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      bash ./scripts/build
+
+      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L23
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp $CRAFT_PART_SRC/bin/backing-image-manager-${CRAFT_ARCH_BUILD_FOR} $CRAFT_PART_INSTALL/usr/local/bin/backing-image-manager
+
+  # Pulls a pre-built binary release of the `tini` init system.
+  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L28-L30
+  fetch-tini-init:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    override-build: |
+      set -eux -o pipefail
+
+      TINI_VERSION="v0.19.0"
+      ARCH="$CRAFT_TARGET_ARCH"
+
+      URL="https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH}"
+
+      curl -sSfL $URL -o $CRAFT_PART_INSTALL/tini
+      chmod +x $CRAFT_PART_INSTALL/tini
+
+  prep-final-image:
+    plugin: nil
+
+    # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L19-L21
+    stage-packages:
+      - kmod
+      - curl
+      - wget
+      - nfs-common              # nfs-client
+      - nfs4-acl-tools
+      - fuse
+      - librdmacm-dev           # librdmacm1
+      - rdmacm-utils            # librdmacm-utils
+      - libibverbs-dev          # libibverbs
+      - libconfig-general-perl  # perl-Config-General
+      - libaio-dev              # libaio-devel
+      - sg3-utils               # sg3_utils
+      - net-tools               # iputils
+      - telnet
+      - iperf3                  # iperf
+      - qemu-utils              # qemu-tools
+      - iproute2
+      - e2fsprogs
+      - xfsprogs
+      - xfslibs-dev             # xfsprogs-devel

--- a/v1.6.2/backing-image-manager/rockcraft.yaml
+++ b/v1.6.2/backing-image-manager/rockcraft.yaml
@@ -2,24 +2,24 @@
 # See LICENSE file for licensing details.
 
 # Rockcraft definition for the Longhorn Backing Image Manager image:
-# longhornio/backing-image-manager:v1.7.0
+# longhornio/backing-image-manager:v1.6.2
 
 name: backing-image-manager
 summary: Rock containing the Longhorn Backing Image Manager component.
 description: |
   Rock containing Longhorn Backing Image manager component: https://github.com/longhorn/backing-image-manager
-  Aims to replicate the upstream official image: longhornio/backing-image-manager:v1.7.0
+  Aims to replicate the upstream official image: longhornio/backing-image-manager:v1.6.2
 license: Apache-2.0
 
-version: "v1.7.0"
+version: "v1.6.2"
 
 # NOTE(aznashwan): the base for the image is the Suse Linux Enterprise
-# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
-# and is thus most comparable to 24.04:
-# https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L3
-base: ubuntu@24.04
+# Base Container Image (SLE BCE) Service Pack 5 which ships with Linux 5.14,
+# and is thus most comparable to 22.04:
+# https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L1
+base: ubuntu@22.04
 
-build-base: ubuntu@24.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
 
@@ -29,7 +29,7 @@ services:
     startup: enabled
     override: replace
 
-    # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L31-L33
+    # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L21-L23
     command: /tini -- [ backing-image-manager ]
 
     on-success: shutdown
@@ -42,12 +42,12 @@ parts:
   # NOTE(aznashwan): the binary is built within a Docker container
   # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
   # The setup steps for the build container are contained within this Dockerfile:
-  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper
+  # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/Dockerfile.dapper
   setup-build-env:
     plugin: nil
 
     build-packages:
-      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper#L20-L24
+      # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/Dockerfile.dapper#L20-L24
       - cmake
       - wget
       - curl
@@ -56,7 +56,7 @@ parts:
       - file
       - libkmod-dev             # libkmod-devel
       - libnl-3-dev             # libnl3-devel
-      - linux-headers-6.8.0-41  # linux-glibc-devel
+      - linux-headers-5.15.0-25 # linux-glibc-devel
       - pkg-config
       - psmisc
       - fuse
@@ -74,20 +74,20 @@ parts:
 
   # NOTE(aznashwan): the Makefile targets are just the scripts found in the
   # scripts/ directory which are executed within the Dapper build container:
-  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Makefile#L1
-  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Makefile#L10-L11
+  # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/Makefile#L1
+  # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/Makefile#L10-L11
   build-lonhorn-backing-image-manager:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/longhorn/backing-image-manager
-    source-tag: v1.7.0
+    source-tag: v1.6.2
     source-depth: 1
 
     build-snaps:
-      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/Dockerfile.dapper#L1
-      - go/1.22/stable
+      # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/Dockerfile.dapper#L36
+      - go/1.21/stable
 
     override-build: |
       set -eux -o pipefail
@@ -96,12 +96,12 @@ parts:
 
       bash ./scripts/build
 
-      # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L23
+      # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L13
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp $CRAFT_PART_SRC/bin/backing-image-manager-${CRAFT_ARCH_BUILD_FOR} $CRAFT_PART_INSTALL/usr/local/bin/backing-image-manager
+      cp $CRAFT_PART_SRC/bin/backing-image-manager $CRAFT_PART_INSTALL/usr/local/bin/backing-image-manager
 
   # Pulls a pre-built binary release of the `tini` init system.
-  # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L28-L30
+  # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L18-L20
   fetch-tini-init:
     plugin: nil
     after: ["setup-build-env"]
@@ -120,7 +120,7 @@ parts:
   prep-final-image:
     plugin: nil
 
-    # https://github.com/longhorn/backing-image-manager/blob/v1.7.0/package/Dockerfile#L19-L21
+    # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L9-L11
     stage-packages:
       - kmod
       - curl

--- a/v1.6.2/longhorn-engine/rockcraft.yaml
+++ b/v1.6.2/longhorn-engine/rockcraft.yaml
@@ -1,0 +1,265 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Rockcraft definition for Longhorn engine image:
+# longhornio/longhorn-engine:v1.7.0
+
+name: longhorn-engine
+summary: Rock containing Longhorn engine component.
+description: |
+  Rock containing Longhorn engine component: https://github.com/longhorn/longhorn-engine
+  Aims to replicate the upstream official image: longhornio/longhorn-engine:v1.7.0
+license: Apache-2.0
+
+version: "v1.7.0"
+
+# NOTE(aznashwan): the base for the engine image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L1
+base: ubuntu@24.04
+
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+
+
+services:
+  longhorn-engine:
+    startup: enabled
+    override: replace
+
+    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L68-L70
+    command: /tini -- [ longhorn ]
+
+parts:
+
+  # NOTE(aznashwan): the longhorn binary is built within a Docker container
+  # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
+  # The setup steps for the build container are contained within this Dockerfile:
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper
+  setup-build-env:
+    plugin: nil
+
+    build-packages:
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L30-L36
+      - cmake
+      - curl
+      - git
+      - less
+      - file
+      - gcc
+      - python3
+      - python3-pip
+      - python3-dev
+      - libkmod-dev
+      - libnl-3-dev
+      - linux-headers-6.8.0-41
+      - pkg-config
+      - psmisc
+      - fuse
+      - librdmacm-dev
+      - rdmacm-utils
+      - libibverbs-dev
+      - xsltproc
+      - docbook-xsl
+      - ldp-docbook-xsl
+      - perl
+      - libconfig-general-perl
+      - libaio-dev
+      - libc6-dev
+      - sg3-utils
+      - iptables
+      - libltdl7
+      - libdevmapper-dev
+      - iproute2
+      - jq
+      - unzip
+      - zlib1g-dev
+      - rdma-core
+      - g++
+      - libopeniscsiusr-dev
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L25-L27
+      - autoconf
+      - libtool
+      - libunwind-dev
+
+    override-build: |
+      set -eux -o pipefail
+
+      # NOTE(aznashwan): pull and install libqcow2 for building the engine:
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L48-L53
+      curl -sSfL https://s3-us-west-1.amazonaws.com/rancher-longhorn/libqcow-alpha-20181117.tar.gz | tar xvzf - -C /usr/src
+
+      cd /usr/src/libqcow-20181117
+      ./configure
+      make -j$(nproc)
+      make install
+
+      ldconfig
+
+      # NOTE(aznashwan): pull and install liblonghorn
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L15-L22
+      LIBLONGHORN_COMMIT_ID="53d1c063b95efc8d949b095bd4bf04637230265f"
+      cd /usr/src
+      git clone https://github.com/rancher/liblonghorn.git
+      cd liblonghorn
+      git checkout ${LIBLONGHORN_COMMIT_ID}
+      make
+      make install
+
+  # NOTE(aznashwan): the Makefile targets are just the scripts found in the
+  # scripts/ directory which are executed within the Dapper build container:
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Makefile#L1
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Makefile#L10-L11
+  build-lonhorn-engine:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/longhorn-engine
+    source-tag: v1.7.0
+    source-depth: 1
+
+    build-snaps:
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L1
+      - go/1.22/stable
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      bash ./scripts/build
+
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L59
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp $CRAFT_PART_SRC/bin/longhorn $CRAFT_PART_INSTALL/usr/local/bin
+
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L62
+      cp package/launch-simple-longhorn $CRAFT_PART_INSTALL/usr/local/bin
+      cp package/engine-manager $CRAFT_PART_INSTALL/usr/local/bin
+      cp package/launch-simple-file $CRAFT_PART_INSTALL/usr/local/bin
+
+  # NOTE(aznashwan): the original engine image includes a Longhorn Instance Manager
+  # binary which is built on the spot within the Dapper build container:
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L60
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L93-L98
+  build-longhorn-instance-manager:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/longhorn-engine
+    # NOTE(aznashwan): the build steps in the Dapper file clone the
+    # longhorn-instance-manager's tip, which could potentially lead
+    # to compatibility issues so we pin its version too:
+    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L95
+    source-tag: v1.7.0
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      go build \
+        -tags netgo -ldflags "-linkmode external -extldflags -static" \
+        -o ./longhorn-instance-manager
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp ./longhorn-instance-manager $CRAFT_PART_INSTALL/usr/local/bin
+
+  build-liblonghorn:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/rancher/liblonghorn.git
+    source-commit: 53d1c063b95efc8d949b095bd4bf04637230265f
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L15-L22
+      cd $CRAFT_PART_SRC
+      make
+      make install
+
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L24-L31
+  build-tgt:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/rancher/tgt.git
+    source-commit: 3a8bc4823b5390e046f7aa8231ed262c0365c42c
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+      make
+      make install
+
+      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L52-L56
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp /usr/sbin/{tgt-admin,tgt-setup-lun,tgtadm,tgtd,tgtimg} $CRAFT_PART_INSTALL/usr/local/bin
+
+  # Pulls a pre-built GRPC health probe executable into the final ROCK.
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L33-L35
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L51
+  fetch-grpc-health-probe:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    override-build: |
+      set -eux -o pipefail
+
+      VERSION="v0.4.28"
+      ARCH="$CRAFT_TARGET_ARCH"
+
+      URL="https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${VERSION}/grpc_health_probe-linux-${ARCH}"
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      curl -sSfL $URL -o $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
+      chmod +x $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
+
+  # Pulls a pre-built binary release of the `tini` init system.
+  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L64-L67
+  fetch-tini-init:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    override-build: |
+      set -eux -o pipefail
+
+      TINI_VERSION="v0.19.0"
+      ARCH="$CRAFT_TARGET_ARCH"
+
+      URL="https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH}"
+
+      curl -sSfL $URL -o $CRAFT_PART_INSTALL/tini
+      chmod +x $CRAFT_PART_INSTALL/tini
+
+  prep-final-image:
+    plugin: nil
+
+    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L45-L46
+    stage-packages:
+      - nfs-common
+      - nfs4-acl-tools
+      - cifs-utils
+      - libaio-dev
+      - sg3-utils
+      # NOTE(aznashwan): original image install 'iputils' SLE package
+      # which contains the utilities from all the below packages:
+      - iputils-arping
+      - iputils-ping
+      - iputils-tracepath
+      - iputils-clockdiff
+      - iproute2
+      - qemu-utils
+      - e2fsprogs

--- a/v1.6.2/longhorn-engine/rockcraft.yaml
+++ b/v1.6.2/longhorn-engine/rockcraft.yaml
@@ -2,34 +2,32 @@
 # See LICENSE file for licensing details.
 
 # Rockcraft definition for Longhorn engine image:
-# longhornio/longhorn-engine:v1.7.0
+# longhornio/longhorn-engine:v1.6.2
 
 name: longhorn-engine
 summary: Rock containing Longhorn engine component.
 description: |
   Rock containing Longhorn engine component: https://github.com/longhorn/longhorn-engine
-  Aims to replicate the upstream official image: longhornio/longhorn-engine:v1.7.0
+  Aims to replicate the upstream official image: longhornio/longhorn-engine:v1.6.2
 license: Apache-2.0
 
-version: "v1.7.0"
+version: "v1.6.2"
 
 # NOTE(aznashwan): the base for the engine image is the Suse Linux Enterprise
-# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
-# and is thus most comparable to 24.04:
-# https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L1
-base: ubuntu@24.04
-
-build-base: ubuntu@24.04
+# Base Container Image (SLE BCE) Service Pack 5 which ships with Linux 5.14,
+# and is thus most comparable to 22.04:
+# https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L1
+base: ubuntu@22.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
-
 
 services:
   longhorn-engine:
     startup: enabled
     override: replace
 
-    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L68-L70
+    # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L66-L68
     command: /tini -- [ longhorn ]
 
 parts:
@@ -37,12 +35,12 @@ parts:
   # NOTE(aznashwan): the longhorn binary is built within a Docker container
   # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
   # The setup steps for the build container are contained within this Dockerfile:
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper
   setup-build-env:
     plugin: nil
 
     build-packages:
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L30-L36
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L28-L33
       - cmake
       - curl
       - git
@@ -54,7 +52,7 @@ parts:
       - python3-dev
       - libkmod-dev
       - libnl-3-dev
-      - linux-headers-6.8.0-41
+      - linux-headers-5.15.0-119-generic
       - pkg-config
       - psmisc
       - fuse
@@ -79,7 +77,7 @@ parts:
       - rdma-core
       - g++
       - libopeniscsiusr-dev
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L25-L27
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L23-L25
       - autoconf
       - libtool
       - libunwind-dev
@@ -88,7 +86,7 @@ parts:
       set -eux -o pipefail
 
       # NOTE(aznashwan): pull and install libqcow2 for building the engine:
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L48-L53
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L57-L64
       curl -sSfL https://s3-us-west-1.amazonaws.com/rancher-longhorn/libqcow-alpha-20181117.tar.gz | tar xvzf - -C /usr/src
 
       cd /usr/src/libqcow-20181117
@@ -99,7 +97,7 @@ parts:
       ldconfig
 
       # NOTE(aznashwan): pull and install liblonghorn
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L15-L22
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L12-L19
       LIBLONGHORN_COMMIT_ID="53d1c063b95efc8d949b095bd4bf04637230265f"
       cd /usr/src
       git clone https://github.com/rancher/liblonghorn.git
@@ -110,20 +108,20 @@ parts:
 
   # NOTE(aznashwan): the Makefile targets are just the scripts found in the
   # scripts/ directory which are executed within the Dapper build container:
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Makefile#L1
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Makefile#L10-L11
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Makefile#L1
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Makefile#L10-L11
   build-lonhorn-engine:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/longhorn/longhorn-engine
-    source-tag: v1.7.0
+    source-tag: v1.6.2
     source-depth: 1
 
     build-snaps:
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L1
-      - go/1.22/stable
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L46
+      - go/1.21/stable
 
     override-build: |
       set -eux -o pipefail
@@ -132,30 +130,27 @@ parts:
 
       bash ./scripts/build
 
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L59
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L56
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
       cp $CRAFT_PART_SRC/bin/longhorn $CRAFT_PART_INSTALL/usr/local/bin
 
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L62
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L58
       cp package/launch-simple-longhorn $CRAFT_PART_INSTALL/usr/local/bin
       cp package/engine-manager $CRAFT_PART_INSTALL/usr/local/bin
       cp package/launch-simple-file $CRAFT_PART_INSTALL/usr/local/bin
 
   # NOTE(aznashwan): the original engine image includes a Longhorn Instance Manager
   # binary which is built on the spot within the Dapper build container:
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L60
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L93-L98
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L56
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L137-L143
   build-longhorn-instance-manager:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/longhorn/longhorn-engine
-    # NOTE(aznashwan): the build steps in the Dapper file clone the
-    # longhorn-instance-manager's tip, which could potentially lead
-    # to compatibility issues so we pin its version too:
-    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/Dockerfile.dapper#L95
-    source-tag: v1.7.0
+    # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L139
+    source-tag: v1.6.x
     source-depth: 1
 
     override-build: |
@@ -182,12 +177,12 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L15-L22
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L12-L19
       cd $CRAFT_PART_SRC
       make
       make install
 
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L24-L31
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L21-L28
   build-tgt:
     plugin: nil
     after: ["setup-build-env"]
@@ -204,13 +199,13 @@ parts:
       make
       make install
 
-      # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L52-L56
+      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L49-L54
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
       cp /usr/sbin/{tgt-admin,tgt-setup-lun,tgtadm,tgtd,tgtimg} $CRAFT_PART_INSTALL/usr/local/bin
 
   # Pulls a pre-built GRPC health probe executable into the final ROCK.
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L33-L35
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L51
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L30-L32
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L48
   fetch-grpc-health-probe:
     plugin: nil
     after: ["setup-build-env"]
@@ -218,7 +213,7 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      VERSION="v0.4.28"
+      VERSION="v0.4.24"
       ARCH="$CRAFT_TARGET_ARCH"
 
       URL="https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${VERSION}/grpc_health_probe-linux-${ARCH}"
@@ -228,7 +223,7 @@ parts:
       chmod +x $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
 
   # Pulls a pre-built binary release of the `tini` init system.
-  # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L64-L67
+  # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L63-L65
   fetch-tini-init:
     plugin: nil
     after: ["setup-build-env"]
@@ -247,7 +242,7 @@ parts:
   prep-final-image:
     plugin: nil
 
-    # https://github.com/longhorn/longhorn-engine/blob/v1.7.0/package/Dockerfile#L45-L46
+    # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L42-L43
     stage-packages:
       - nfs-common
       - nfs4-acl-tools

--- a/v1.6.2/longhorn-instance-manager/pebble-entrypoint.sh
+++ b/v1.6.2/longhorn-instance-manager/pebble-entrypoint.sh
@@ -13,10 +13,10 @@ ldconfig
 
 TINI_ARGS="$@"
 if [ $# -eq 0 ]; then
-    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L177
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L146
     # https://github.com/longhorn/longhorn-instance-manager/pull/664
     TINI_ARGS="longhorn-instance-manager"
 fi
 
-# https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L175
+# https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L144
 exec /tini -- $TINI_ARGS

--- a/v1.6.2/longhorn-instance-manager/pebble-entrypoint.sh
+++ b/v1.6.2/longhorn-instance-manager/pebble-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Required to prevent Pebble from considering the service to have
+# exited too quickly to be worth restarting or respecting the
+# "on-failure: shutdown" directive and thus hanging indefinitely:
+# https://github.com/canonical/pebble/issues/240#issuecomment-1599722443
+sleep 1.1
+
+# NOTE(aznashwan): the longhorn-instance-manager image includes a number of
+# dynamically-linked binaries which the instance-manager exec's.
+# These binaries require some external libraries which must be indexed:
+ldconfig
+
+TINI_ARGS="$@"
+if [ $# -eq 0 ]; then
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L177
+    # https://github.com/longhorn/longhorn-instance-manager/pull/664
+    TINI_ARGS="longhorn-instance-manager"
+fi
+
+# https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L175
+exec /tini -- $TINI_ARGS

--- a/v1.6.2/longhorn-instance-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-instance-manager/rockcraft.yaml
@@ -2,23 +2,23 @@
 # See LICENSE file for licensing details.
 
 # Rockcraft definition for Longhorn Instance Manager image:
-# longhornio/longhorn-instance-manager:v1.7.0
+# longhornio/longhorn-instance-manager:v1.6.2
 
 name: longhorn-instance-manager
 summary: Rock containing Longhorn Instance Manager component.
 description: |
   Rock containing Longhorn Instance Manager component: https://github.com/longhorn/longhorn-instance-manager
-  Aims to replicate the upstream official image: longhornio/longhorn-instance-manager:v1.7.0
+  Aims to replicate the upstream official image: longhornio/longhorn-instance-manager:v1.6.2
 license: Apache-2.0
 
-version: "v1.7.0"
+version: "v1.6.2"
 
 # NOTE(aznashwan): the base for the Instance Manager image is the Suse Linux Enterprise
-# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
-# and is thus most comparable to 24.04:
-# https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L44
-base: ubuntu@24.04
-build-base: ubuntu@24.04
+# Base Container Image (SLE BCE) Service Pack 5 which ships with Linux 5.14,
+# and is thus most comparable to 22.04:
+# https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L92
+base: ubuntu@22.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
 
@@ -44,12 +44,12 @@ parts:
   # NOTE(aznashwan): the longhorn binary is built within a Docker container
   # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
   # The setup steps for the build container are contained within this Dockerfile:
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper
   setup-build-env:
     plugin: nil
 
     build-packages:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L24-L29
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L23-L27
       - cmake
       - wget
       - curl
@@ -58,7 +58,7 @@ parts:
       - libglib2.0-dev          # libglib-2_0-0
       - libkmod-dev             # libkmod-devel
       - libnl-3-dev             # libnl3-devel
-      - linux-headers-6.8.0-41  # linux-glibc-devel
+      - linux-headers-5.15.0-25 # linux-glibc-devel
       - pkg-config
       - psmisc
       - fuse
@@ -74,19 +74,12 @@ parts:
       - libdevmapper1.02.1      # libdevmapper1_03
       - gcc
       - g++
-      # The following are packages used for building supporting libs in a
-      # separate multi-stage build before copying them to the final image:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L54
-      - python3                 # python311
-      - python3-pip             # python311-pip
-      - patchelf
-      - libfuse3-3              # fuse3-devel
 
     override-build: |
       set -eux -o pipefail
 
       # NOTE(aznashwan): pull and install libqcow2 for building the engine deps:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L36-L41
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L43-L51
       curl -sSfL https://s3-us-west-1.amazonaws.com/rancher-longhorn/libqcow-alpha-20181117.tar.gz | tar xvzf - -C /usr/src
 
       cd /usr/src/libqcow-20181117
@@ -105,11 +98,11 @@ parts:
 
     source-type: git
     source: https://github.com/longhorn/longhorn-instance-manager
-    source-tag: v1.7.0
+    source-tag: v1.6.2
     source-depth: 1
 
     build-snaps:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L1
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L40
       - go/1.22/stable
 
     override-build: |
@@ -119,7 +112,7 @@ parts:
 
       bash ./scripts/build
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L165-L166
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L136
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
       cp $CRAFT_PART_SRC/bin/longhorn-instance-manager $CRAFT_PART_INSTALL/usr/local/bin
 
@@ -130,18 +123,23 @@ parts:
       cat package/instance-manager >> $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
       chmod +x $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L18-L26
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L20-L25
   build-go-spdk-helper:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/longhorn/go-spdk-helper
+    # NOTE(aznashwan): the original v1.6.2 version of the Dockerfile
+    # did not bother to pin the go-spdk-helper version...
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L21
+    # This commit ID is the one used in the v1.7.0 image:
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L20
     source-commit: 6a324e95979662be592bfda0e867d2678ecbc756
     source-depth: 1
 
     build-snaps:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L1
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L1
       - go/1.22/stable
 
     override-build: |
@@ -155,8 +153,8 @@ parts:
       chmod 755 $CRAFT_PART_INSTALL/usr/local/bin/go-spdk-helper
 
   # Pulls a pre-built GRPC health probe executable into the final ROCK.
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L28-L30
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L139
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L89-L90
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L113
   fetch-grpc-health-probe:
     plugin: nil
     after: ["setup-build-env"]
@@ -164,7 +162,7 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      VERSION="v0.4.28"
+      VERSION="v0.4.24"
       ARCH="$CRAFT_ARCH_BUILD_FOR"
 
       URL="https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${VERSION}/grpc_health_probe-linux-${ARCH}"
@@ -173,7 +171,7 @@ parts:
       curl -sSfL $URL -o $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
       chmod +x $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L56-L62
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L28-L34
   build-liblonghorn:
     plugin: nil
     after: ["setup-build-env"]
@@ -190,7 +188,7 @@ parts:
       make
       make install
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L64-L70
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L37-L43
   build-tgt:
     plugin: nil
     after: ["setup-build-env"]
@@ -207,18 +205,18 @@ parts:
       make
       make install
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L151-L157
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L122-L128
       mkdir -p $CRAFT_PART_INSTALL/usr/sbin
       cp /usr/sbin/{tgt-admin,tgt-setup-lun,tgtadm,tgtd,tgtimg} $CRAFT_PART_INSTALL/usr/sbin
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L72-L93
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L47-L64
   build-spdk:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/longhorn/spdk
-    source-commit: a6478cde7e0cff2fb09992868308a7387aa5202a
+    source-commit: 086836c8d1ee2d622c86965dfb0245d966420309
 
     override-build: |
       set -eux -o pipefail
@@ -227,9 +225,8 @@ parts:
 
       git submodule update --init
 
-      sed -i.bak "s/pip3 install/pip3 install --break-system-packages/g" ./scripts/pkgdep/ubuntu.sh
       bash ./scripts/pkgdep.sh
-      pip3 install --break-system-packages -r ./scripts/pkgdep/requirements.txt
+      pip3 install -r ./scripts/pkgdep/requirements.txt
 
       TARGET_ARCH="unsupported"
       DPDKBUILD_FLAGS=""
@@ -247,11 +244,11 @@ parts:
       DPDKBUILD_FLAGS="$DPDKBUILD_FLAGS" make -j$(nproc)
       make install
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L143-L145
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L114
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
       cp /usr/local/bin/spdk_* $CRAFT_PART_INSTALL/usr/local/bin
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L95-L104
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L67-L76
   build-json-c:
     plugin: nil
     after: ["setup-build-env"]
@@ -273,20 +270,20 @@ parts:
       make
       make install
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L159-L161
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L130-L132
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
       cp --preserve=links /usr/local/lib/libjson-c* $CRAFT_PART_INSTALL/usr/local/lib/
 
       ldconfig -p
 
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L106-L113
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L78-L86
   build-nvme-cli:
     plugin: nil
     after: ["setup-build-env"]
 
     source-type: git
     source: https://github.com/linux-nvme/nvme-cli
-    source-commit: b340fd7dcf1aef76f8d46ab28bef3c170d310887
+    source-commit: dcdad6f5d70ffb2fa151f229db048180671eb1fe
     source-depth: 1
 
     build-packages:
@@ -301,18 +298,18 @@ parts:
       meson compile -C .build
       meson install -C .build
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L147-L149
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L118-L120
       mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin
       cp /usr/local/sbin/nvme $CRAFT_PART_INSTALL/usr/local/sbin
 
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L159-L161
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L130-L132
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
       cp --preserve=links /usr/local/lib/*/libnvme*.so $CRAFT_PART_INSTALL/usr/local/lib/
 
       ldconfig -p
 
   # Pulls a pre-built binary release of the `tini` init system.
-  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L173
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L141-L143
   fetch-tini-init:
     plugin: nil
     after: ["setup-build-env"]
@@ -331,7 +328,7 @@ parts:
   prep-final-image:
     plugin: nil
 
-    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L128-L129
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L103-L105
     stage-packages:
       - nfs-common        # nfs-client
       - nfs4-acl-tools

--- a/v1.6.2/longhorn-instance-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-instance-manager/rockcraft.yaml
@@ -1,0 +1,383 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Rockcraft definition for Longhorn Instance Manager image:
+# longhornio/longhorn-instance-manager:v1.7.0
+
+name: longhorn-instance-manager
+summary: Rock containing Longhorn Instance Manager component.
+description: |
+  Rock containing Longhorn Instance Manager component: https://github.com/longhorn/longhorn-instance-manager
+  Aims to replicate the upstream official image: longhornio/longhorn-instance-manager:v1.7.0
+license: Apache-2.0
+
+version: "v1.7.0"
+
+# NOTE(aznashwan): the base for the Instance Manager image is the Suse Linux Enterprise
+# Base Container Image (SLE BCE) Service Pack 6 which ships with Linux 6.4,
+# and is thus most comparable to 24.04:
+# https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L44
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+
+environment:
+  LD_LIBRARY_PATH: /usr/local/lib
+
+services:
+  longhorn-instance-manager:
+    summary: "longhorn-instance-manager service"
+    startup: enabled
+    override: replace
+
+    # NOTE(aznashwan): the entrypoint script we add to the rock simply runs
+    # `ldconfig` before `exec`-ing the `tini` init service with the args:
+    command: bash /pebble-entrypoint.sh [ longhorn-instance-manager ]
+
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: longhorn-instance-manager
+
+parts:
+  # NOTE(aznashwan): the longhorn binary is built within a Docker container
+  # which is set up by Rancher's Dapper tool: https://github.com/rancher/dapper
+  # The setup steps for the build container are contained within this Dockerfile:
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper
+  setup-build-env:
+    plugin: nil
+
+    build-packages:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L24-L29
+      - cmake
+      - wget
+      - curl
+      - git
+      - file
+      - libglib2.0-dev          # libglib-2_0-0
+      - libkmod-dev             # libkmod-devel
+      - libnl-3-dev             # libnl3-devel
+      - linux-headers-6.8.0-41  # linux-glibc-devel
+      - pkg-config
+      - psmisc
+      - fuse
+      - zlib1g-dev              # zlib-devel
+      - rdma-core               # rdma-core-devel
+      - librdmacm-dev
+      - xsltproc
+      - docbook-xsl
+      - ldp-docbook-xsl
+      - libaio-dev              # libaio-devel
+      - libc6-dev               # glibc-devel, glibc-devel-static
+      - libltdl7
+      - libdevmapper1.02.1      # libdevmapper1_03
+      - gcc
+      - g++
+      # The following are packages used for building supporting libs in a
+      # separate multi-stage build before copying them to the final image:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L54
+      - python3                 # python311
+      - python3-pip             # python311-pip
+      - patchelf
+      - libfuse3-3              # fuse3-devel
+
+    override-build: |
+      set -eux -o pipefail
+
+      # NOTE(aznashwan): pull and install libqcow2 for building the engine deps:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L36-L41
+      curl -sSfL https://s3-us-west-1.amazonaws.com/rancher-longhorn/libqcow-alpha-20181117.tar.gz | tar xvzf - -C /usr/src
+
+      cd /usr/src/libqcow-20181117
+      ./configure
+      make -j$(nproc)
+      make install
+
+      ldconfig -p
+
+  # The Makefile targets are just the scripts found in the scripts/ directory which
+  # are executed within the Dapper build container:
+  # https://github.com/longhorn/longhorn-instance-manager/blob/master/Makefile#L10-L11
+  build-longhorn-instance-manager:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/longhorn-instance-manager
+    source-tag: v1.7.0
+    source-depth: 1
+
+    build-snaps:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L1
+      - go/1.22/stable
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      bash ./scripts/build
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L165-L166
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp $CRAFT_PART_SRC/bin/longhorn-instance-manager $CRAFT_PART_INSTALL/usr/local/bin
+
+      # NOTE(aznashwan): the original script is lacking any error
+      # handling/debugging so we add it ourselves:
+      echo '#!/bin/bash' >> $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
+      echo 'set -eux -o pipefail' >> $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
+      cat package/instance-manager >> $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
+      chmod +x $CRAFT_PART_INSTALL/usr/local/bin/instance-manager
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L18-L26
+  build-go-spdk-helper:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/go-spdk-helper
+    source-commit: 6a324e95979662be592bfda0e867d2678ecbc756
+    source-depth: 1
+
+    build-snaps:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/Dockerfile.dapper#L1
+      - go/1.22/stable
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+      go build
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp go-spdk-helper $CRAFT_PART_INSTALL/usr/local/bin/go-spdk-helper
+      chmod 755 $CRAFT_PART_INSTALL/usr/local/bin/go-spdk-helper
+
+  # Pulls a pre-built GRPC health probe executable into the final ROCK.
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L28-L30
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L139
+  fetch-grpc-health-probe:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    override-build: |
+      set -eux -o pipefail
+
+      VERSION="v0.4.28"
+      ARCH="$CRAFT_ARCH_BUILD_FOR"
+
+      URL="https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${VERSION}/grpc_health_probe-linux-${ARCH}"
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      curl -sSfL $URL -o $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
+      chmod +x $CRAFT_PART_INSTALL/usr/local/bin/grpc_health_probe
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L56-L62
+  build-liblonghorn:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/rancher/liblonghorn
+    source-commit: 53d1c063b95efc8d949b095bd4bf04637230265f
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+      make
+      make install
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L64-L70
+  build-tgt:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/rancher/tgt.git
+    source-commit: 3a8bc4823b5390e046f7aa8231ed262c0365c42c
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+      make
+      make install
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L151-L157
+      mkdir -p $CRAFT_PART_INSTALL/usr/sbin
+      cp /usr/sbin/{tgt-admin,tgt-setup-lun,tgtadm,tgtd,tgtimg} $CRAFT_PART_INSTALL/usr/sbin
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L72-L93
+  build-spdk:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/longhorn/spdk
+    source-commit: a6478cde7e0cff2fb09992868308a7387aa5202a
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      git submodule update --init
+
+      sed -i.bak "s/pip3 install/pip3 install --break-system-packages/g" ./scripts/pkgdep/ubuntu.sh
+      bash ./scripts/pkgdep.sh
+      pip3 install --break-system-packages -r ./scripts/pkgdep/requirements.txt
+
+      TARGET_ARCH="unsupported"
+      DPDKBUILD_FLAGS=""
+      if [ $CRAFT_ARCH_BUILD_FOR = "amd64" ]; then
+        TARGET_ARCH="nehalem"
+      elif [ $CRAFT_ARCH_BUILD_FOR = "arm64" ]; then
+        TARGET_ARCH="native"
+        DPDKBUILD_FLAGS="-Dplatform=generic"
+      else
+        echo "Unsupported architecture: ${CRAFT_ARCH_BUILD_FOR}"
+        exit 1
+      fi
+
+      ./configure --target-arch=$TARGET_ARCH --disable-tests --disable-unit-tests --disable-examples
+      DPDKBUILD_FLAGS="$DPDKBUILD_FLAGS" make -j$(nproc)
+      make install
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L143-L145
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp /usr/local/bin/spdk_* $CRAFT_PART_INSTALL/usr/local/bin
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L95-L104
+  build-json-c:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/json-c/json-c
+    source-commit: b4c371fa0cbc4dcbaccc359ce9e957a22988fb34
+    source-depth: 1
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      mkdir -p .build
+      cd .build
+
+      cmake ../
+      make
+      make install
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L159-L161
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
+      cp --preserve=links /usr/local/lib/libjson-c* $CRAFT_PART_INSTALL/usr/local/lib/
+
+      ldconfig -p
+
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L106-L113
+  build-nvme-cli:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    source-type: git
+    source: https://github.com/linux-nvme/nvme-cli
+    source-commit: b340fd7dcf1aef76f8d46ab28bef3c170d310887
+    source-depth: 1
+
+    build-packages:
+      - meson
+
+    override-build: |
+      set -eux -o pipefail
+
+      cd $CRAFT_PART_SRC
+
+      meson setup --force-fallback-for=libnvme .build
+      meson compile -C .build
+      meson install -C .build
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L147-L149
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin
+      cp /usr/local/sbin/nvme $CRAFT_PART_INSTALL/usr/local/sbin
+
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L159-L161
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib
+      cp --preserve=links /usr/local/lib/*/libnvme*.so $CRAFT_PART_INSTALL/usr/local/lib/
+
+      ldconfig -p
+
+  # Pulls a pre-built binary release of the `tini` init system.
+  # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L173
+  fetch-tini-init:
+    plugin: nil
+    after: ["setup-build-env"]
+
+    override-build: |
+      set -eux -o pipefail
+
+      TINI_VERSION="v0.19.0"
+      ARCH="$CRAFT_ARCH_BUILD_FOR"
+
+      URL="https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH}"
+
+      curl -sSfL $URL -o $CRAFT_PART_INSTALL/tini
+      chmod +x $CRAFT_PART_INSTALL/tini
+
+  prep-final-image:
+    plugin: nil
+
+    # https://github.com/longhorn/longhorn-instance-manager/blob/v1.7.0/package/Dockerfile#L128-L129
+    stage-packages:
+      - nfs-common        # nfs-client
+      - nfs4-acl-tools
+      - cifs-utils
+      - sg3-utils         # sg3_utils
+      - iproute2
+      - qemu-utils        # qemu-utils, for `qemu-img` binary
+      - e2fsprogs
+      - xfsprogs
+      - util-linux        # util-linux-systemd
+      - python3           # python311-base
+      - libcmocka-dev     # libcmocka-devel
+      # NOTE(aznashwan): the below 'dm*' packages are constituents of the
+      # 'device-mapper' SLES package which aggregates the following:
+      - dmsetup
+      - dmeventd
+      - netcat-openbsd    # netcat
+      - kmod
+      - jq
+      - util-linux
+      - procps
+      - libfuse3-3        # fuse3-devel
+      - awk
+      # NOTE(aznashwan): although not explicitly installed in any of the
+      # upstream build procedures, some of the secondary CLI tools
+      # (e.g. nvmecli) require libncurses:
+      - libncurses-dev
+
+    override-build: |
+      set -eux -o pipefail
+
+      mkdir -p $CRAFT_PART_INSTALL/etc/ld.so.conf.d
+      echo /usr/local/lib > $CRAFT_PART_INSTALL/etc/ld.so.conf.d/99_usr_local_lib.conf
+
+      cp $CRAFT_PROJECT_DIR/pebble-entrypoint.sh $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/pebble-entrypoint.sh
+
+      # NOTE(aznashwan): the entrypoint helper script included in the upstream
+      # image rbind's /lib/modules so we must ensure the directory exists:
+      # https://github.com/longhorn/longhorn-instance-manager/blob/master/package/instance-manager#L24
+      mkdir -p $CRAFT_PART_INSTALL/lib/modules
+
+      # NOTE(aznashwan): in the original image based on SLES, there is no
+      # `netcat` package, and `zypper -n` instead defaults to the first
+      # package which provides the `netcat` capability, which is the OpenBSD
+      # version of netcat. The `netcat-openbsd` package on Ubuntu only lacks
+      # the `nc` symlink, which we create manually instead:
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      ln -s /bin/nc.openbsd $CRAFT_PART_INSTALL/usr/bin/nc

--- a/v1.7.0/longhorn-engine/rockcraft.yaml
+++ b/v1.7.0/longhorn-engine/rockcraft.yaml
@@ -263,3 +263,4 @@ parts:
       - iproute2
       - qemu-utils
       - e2fsprogs
+      - jq


### PR DESCRIPTION
Note to reviewers: please check the individual commits featuring the changes for each individual Rockfile for a clearer overview of what's changed from the already-merge `v1.7.0` ROCKs.