### PR TITLE
Fixes integration tests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
 
   run-tests:
-     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+     uses: ./.github/workflows/run_tests.yaml
      needs: [build-and-push-arch-specifics]
      secrets: inherit
      with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,62 @@
+name: Run rocks tests
+
+on:
+  workflow_call:
+    inputs:
+      rock-metas:
+        description: List of maps featuring the built {name, version, path, arch, image}
+        type: string
+        default: "[]"
+
+jobs:
+  run-tests:
+    if: ${{ inputs.rock-metas != '[]' }}
+    name: Run tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v4.1
+        with:
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-swapfile: 'true'
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          pip install tox
+      - name: Install multipass
+        run: |
+          set -x
+          sudo snap install multipass
+
+          # We need to authenticate into multipass, since we're not running as root.
+          # https://github.com/canonical/multipass/issues/1437#issuecomment-1435357872
+          sudo multipass set local.passphrase=Passw0rd
+
+          for i in {0..4}; do
+            # If we auth too soon, we might get this error:
+            # authenticate failed: cannot connect to the multipass socket
+            multipass auth Passw0rd && break
+            sleep 1
+          done
+      - name: Run sanity tests
+        env:
+          BUILT_ROCKS_METADATA: ${{ inputs.rock-metas }}
+        run: |
+          tox --conf tests/tox.ini -e sanity
+      - name: Run integration tests
+        env:
+          BUILT_ROCKS_METADATA: ${{ inputs.rock-metas }}
+        run: |
+          export TEST_SUBSTRATE=multipass
+          export TEST_MULTIPASS_MEMORY=6G
+          export TEST_MULTIPASS_DISK=40G
+          tox --conf tests/tox.ini -e integration

--- a/tests/integration/test_longhorn_in_helm_chart.py
+++ b/tests/integration/test_longhorn_in_helm_chart.py
@@ -98,6 +98,17 @@ def test_longhorn_helm_chart_deployment(
     function_instance: harness.Instance, image_version: str
 ):
 
+    # Install prerequisites.
+    base_url = f"https://raw.githubusercontent.com/longhorn/longhorn/{image_version}/deploy/prerequisite"
+    for yaml_file in [
+        "longhorn-iscsi-installation.yaml",
+        "longhorn-nfs-installation.yaml",
+    ]:
+        url = f"{base_url}/{yaml_file}"
+        process = function_instance.exec(
+            ["k8s", "kubectl", "apply", "-f", url], check=True
+        )
+
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     # Compose the Helm command line args for overriding the


### PR DESCRIPTION
There are a few issues running the Longhorn integration tests on an LXD runner, as we currently are, mainly having to do with ISCSI volumes being exposed and mounted in LXD.

Running on host has its own issues, mainly the Pods have cluster-wide connectivity issues.

Instead, we'll be testing Longhorn in a multipass VM. We also remove some of the GitHub runner's bloat in order to free up sufficient space for the VM and test. Note that according to the Longhorn deployment guide, Longhorn requires 25% of the root disk to be available (if no other disks are available).

According to the deployment guide, the node requires ``open-iscsi`` and ``nfs-common``. These daemonsets will install them on the host.