### PR TITLE
Fixes longhorn-share-manager rocks

### DIFF
--- a/v1.6.2/longhorn-share-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-share-manager/rockcraft.yaml
@@ -28,9 +28,11 @@ services:
     startup: enabled
     override: replace
     # https://github.com/longhorn/longhorn-share-manager/blob/v1.6.2/package/Dockerfile#L72
-    command: "/longhorn-share-manager"
+    command: "/longhorn-share-manager [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: longhorn-share-manager
 
 parts:
   # NOTE(aznashwan): the longhorn binary is built within a Docker container

--- a/v1.7.0/longhorn-share-manager/rockcraft.yaml
+++ b/v1.7.0/longhorn-share-manager/rockcraft.yaml
@@ -28,9 +28,11 @@ services:
     startup: enabled
     override: replace
     # https://github.com/longhorn/longhorn-share-manager/blob/v1.7.0/package/Dockerfile#L44
-    command: "/longhorn-share-manager"
+    command: "/longhorn-share-manager [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: longhorn-share-manager
 
 parts:
   # NOTE(aznashwan): the longhorn binary is built within a Docker container


### PR DESCRIPTION
The longhorn helm chart passes arguments to the ``longhorn-share-manager`` entrypoint. Our rock should pass these arguments to the entrypoint service.