### PR TITLE
Fixes lint

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -47,6 +47,9 @@ jobs:
             multipass auth Passw0rd && break
             sleep 1
           done
+      - name: Run lint
+        run: |
+          tox --conf tests/tox.ini -e lint
       - name: Run sanity tests
         env:
           BUILT_ROCKS_METADATA: ${{ inputs.rock-metas }}

--- a/tests/sanity/test_longhorn_backing_image_manager.py
+++ b/tests/sanity/test_longhorn_backing_image_manager.py
@@ -30,10 +30,7 @@ def test_check_rock_image_contents(image_version):
     )
     rock_image = rock_meta.image
 
-    binary_paths_to_check = [
-        "/tini",
-        "/usr/local/bin/backing-image-manager"
-    ]
+    binary_paths_to_check = ["/tini", "/usr/local/bin/backing-image-manager"]
 
     docker_util.ensure_image_contains_paths(
         rock_image,

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -74,7 +74,7 @@ pass_env =
 [flake8]
 max-line-length = 120
 select = E,W,F,C,N
-# E231 rule is not aware of f-strings
-ignore = W503,E231
+# E231, E713 rules are not aware of f-strings
+ignore = W503,E231,E713
 exclude = venv,.git,.tox,.tox_env,.venv,build,dist,*.egg_info
 show-source = true


### PR DESCRIPTION
Fixed issues from running ``tox -e format``.

Added step to check lints in the ``run_tests`` action.