### PR TITLE
Adds nfsv4 PVC scenario to the integration test

### DIFF
--- a/tests/templates/nginx-nfs-pod.yaml
+++ b/tests/templates/nginx-nfs-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: longhorn-nfs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-longhorn-nfs-example
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+      - name: longhorn-pvc
+        mountPath: /var/www
+        readOnly: false
+  volumes:
+    - name: longhorn-pvc
+      persistentVolumeClaim:
+        claimName: longhorn-nfs-pvc


### PR DESCRIPTION
The ``longhorn-share-manager`` rock is currently untested because it's not needed for ``ReadWriteOnce`` PVCs (``ext4`` volumes).

The integration test now also creates a Pod with a ``ReadWriteMany`` PVC, which will result in a ``nfsv4`` mount, which will require the ``longhorn-share-manager`` rock to work properly.