### PR TITLE
Cleanup v1.6.2 rocks

### DIFF
--- a/v1.6.2/backing-image-manager/rockcraft.yaml
+++ b/v1.6.2/backing-image-manager/rockcraft.yaml
@@ -92,13 +92,11 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
-
       bash ./scripts/build
 
       # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L13
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp $CRAFT_PART_SRC/bin/backing-image-manager $CRAFT_PART_INSTALL/usr/local/bin/backing-image-manager
+      cp bin/backing-image-manager $CRAFT_PART_INSTALL/usr/local/bin/backing-image-manager
 
   # Pulls a pre-built binary release of the `tini` init system.
   # https://github.com/longhorn/backing-image-manager/blob/v1.6.2/package/Dockerfile#L18-L20

--- a/v1.6.2/longhorn-engine/rockcraft.yaml
+++ b/v1.6.2/longhorn-engine/rockcraft.yaml
@@ -96,16 +96,6 @@ parts:
 
       ldconfig
 
-      # NOTE(aznashwan): pull and install liblonghorn
-      # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L12-L19
-      LIBLONGHORN_COMMIT_ID="53d1c063b95efc8d949b095bd4bf04637230265f"
-      cd /usr/src
-      git clone https://github.com/rancher/liblonghorn.git
-      cd liblonghorn
-      git checkout ${LIBLONGHORN_COMMIT_ID}
-      make
-      make install
-
   # NOTE(aznashwan): the Makefile targets are just the scripts found in the
   # scripts/ directory which are executed within the Dapper build container:
   # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Makefile#L1
@@ -126,13 +116,11 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
-
       bash ./scripts/build
 
       # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L56
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp $CRAFT_PART_SRC/bin/longhorn $CRAFT_PART_INSTALL/usr/local/bin
+      cp bin/longhorn $CRAFT_PART_INSTALL/usr/local/bin
 
       # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L58
       cp package/launch-simple-longhorn $CRAFT_PART_INSTALL/usr/local/bin
@@ -148,15 +136,13 @@ parts:
     after: ["setup-build-env"]
 
     source-type: git
-    source: https://github.com/longhorn/longhorn-engine
+    source: https://github.com/longhorn/longhorn-instance-manager
     # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/Dockerfile.dapper#L139
     source-tag: v1.6.x
     source-depth: 1
 
     override-build: |
       set -eux -o pipefail
-
-      cd $CRAFT_PART_SRC
 
       go build \
         -tags netgo -ldflags "-linkmode external -extldflags -static" \
@@ -178,7 +164,6 @@ parts:
       set -eux -o pipefail
 
       # https://github.com/longhorn/longhorn-engine/blob/v1.6.2/package/Dockerfile#L12-L19
-      cd $CRAFT_PART_SRC
       make
       make install
 
@@ -195,7 +180,6 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
       make
       make install
 

--- a/v1.6.2/longhorn-instance-manager/rockcraft.yaml
+++ b/v1.6.2/longhorn-instance-manager/rockcraft.yaml
@@ -108,13 +108,11 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
-
       bash ./scripts/build
 
       # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/package/Dockerfile#L136
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp $CRAFT_PART_SRC/bin/longhorn-instance-manager $CRAFT_PART_INSTALL/usr/local/bin
+      cp bin/longhorn-instance-manager $CRAFT_PART_INSTALL/usr/local/bin
 
       # NOTE(aznashwan): the original script is lacking any error
       # handling/debugging so we add it ourselves:
@@ -139,13 +137,12 @@ parts:
     source-depth: 1
 
     build-snaps:
-      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L1
+      # https://github.com/longhorn/longhorn-instance-manager/blob/v1.6.2/Dockerfile.dapper#L40
       - go/1.22/stable
 
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
       go build
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
@@ -184,7 +181,6 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
       make
       make install
 
@@ -201,7 +197,6 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
       make
       make install
 
@@ -220,8 +215,6 @@ parts:
 
     override-build: |
       set -eux -o pipefail
-
-      cd $CRAFT_PART_SRC
 
       git submodule update --init
 
@@ -261,8 +254,6 @@ parts:
     override-build: |
       set -eux -o pipefail
 
-      cd $CRAFT_PART_SRC
-
       mkdir -p .build
       cd .build
 
@@ -291,8 +282,6 @@ parts:
 
     override-build: |
       set -eux -o pipefail
-
-      cd $CRAFT_PART_SRC
 
       meson setup --force-fallback-for=libnvme .build
       meson compile -C .build


### PR DESCRIPTION
The ``longhorn-engine`` rock should contain the ``longhorn-instance-manager``, but ``longhorn-engine`` is built and included instead.

Removes redundant ``liblonghorn`` clone and installation.

Removes redundant cd ``$CRAFT_PART_SRC``.